### PR TITLE
Update C++ extensions installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ CUDA and C++ extensions via
 ```
 $ git clone https://github.com/NVIDIA/apex
 $ cd apex
-$ pip install -v --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" ./
+$ python setup.py install --cuda_ext --cpp_ext
 ```
 
 Apex also supports a Python-only build (required with Pytorch 0.4) via


### PR DESCRIPTION
Installing apex with the C++ extensions using:
```
pip install -v --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" ./
```
seems to only install apex_C and amp_C. For me, installing using:
```
python setup.py install --cuda_ext --cpp_ext
```
did the trick 🙂.
Maybe this should be the default instructions in the README ?